### PR TITLE
Add support for many elements

### DIFF
--- a/web/interop.js
+++ b/web/interop.js
@@ -1,9 +1,24 @@
-class DemoElement extends HTMLElement {
-  constructor() {
-    super();
-    // createInstance is provided by Dart.
-    DemoElement.createInstance(this);
+class CustomElement extends HTMLElement {
+  constructor() { 
+    super(); 
+    this.asDart = null;
+  }
+
+  connectedCallback() {
+    this.asDart.connected();
+  }
+
+  disconnectedCallback() {
+    this.asDart.disconnected();
   }
 }
-window.DemoElement = DemoElement;
-customElements.define('dart-demo', DemoElement);
+window.CustomElement = CustomElement;
+
+function defineElement(name, construct) {
+  customElements.define(name, class extends CustomElement {
+    constructor() {
+      super();
+      construct(this);
+    }
+  });
+};

--- a/web/main.dart
+++ b/web/main.dart
@@ -4,26 +4,52 @@ library main;
 import 'dart:html';
 import 'package:js/js.dart';
 
-@JS('DemoElement')
-abstract class JSDemoElement implements HtmlElement {
-  DemoElement asDart;
-
-  static DemoElement Function(JSDemoElement e) createInstance;
+@JS('CustomElement')
+abstract class JSCustomElement<T extends CustomElement> implements HtmlElement {
+  T asDart;
 }
 
-class DemoElement {
-  final JSDemoElement _element;
-  DemoElement(this._element) {
-    _element.asDart = this;
+typedef CustomElementConstructor = CustomElement Function(JSCustomElement e);
+
+@JS('defineElement')
+external void defineElement(String name, CustomElementConstructor constructor);
+
+class CustomElement {
+  final JSCustomElement element;
+
+  CustomElement(this.element) {
+    element.asDart = this;
   }
+
+  void connected() {}
+  void disconnected() {}
+}
+
+class HelloElement extends CustomElement{
+  HelloElement(JSCustomElement element) : super(element);
+
   void sayHello() {
-    _element.text = 'Hello from Dart!';
-    _element.style.color = '#0175C2';
+    element.text = 'Hello from Dart!';
+    element.style.color = '#0175C2';
+  }
+}
+
+class GoodbyeElement extends CustomElement {
+  GoodbyeElement(JSCustomElement element) : super(element);
+
+  void sayGoodybe() {
+    element.text = 'Goodbye from Dart!';
+    element.style.color = '#0175C2';
   }
 }
 
 void main() {
-  JSDemoElement.createInstance = allowInterop((e) => DemoElement(e));
-  var demo = document.body.append(Element.tag('dart-demo')) as JSDemoElement;
-  demo.asDart.sayHello();
+  defineElement('dart-goodbye', allowInterop((e) => GoodbyeElement(e)));
+  defineElement('dart-hello', allowInterop((e) => HelloElement(e)));
+
+  var hello = document.body.append(Element.tag('dart-hello')) as JSCustomElement<HelloElement>;
+  hello.asDart.sayHello();
+
+  var goodbye = document.body.append(Element.tag('dart-goodbye')) as JSCustomElement<GoodbyeElement>;
+  goodbye.asDart.sayGoodybe();
 }


### PR DESCRIPTION
@jmesserly just taking a stab at making this a bit more extensible. The `connected` `disconnected` I'm guessing would completely fail if compiled out with dart2js.